### PR TITLE
Declare dependencies as documented here (and use alphabetical order):

### DIFF
--- a/hk-kafka-topics-connector.cabal
+++ b/hk-kafka-topics-connector.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 805e13277a3d1530502e7082c6839c73e7963e7d3123b53f9dcd601dbd306e99
+-- hash: 1f52741362dcafbb6b0e90a1ad129cf380223e2b9433ceb36bc68a165aa8210c
 
 name:           hk-kafka-topics-connector
 version:        0.1.0.0
@@ -34,8 +34,8 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , bytestring >=0.10.10.0 && <1
-    , hw-kafka-client >=3.1.0 && <4
+    , bytestring
+    , hw-kafka-client
   default-language: Haskell2010
 
 executable hk-kafka-topics-connector-exe
@@ -47,9 +47,9 @@ executable hk-kafka-topics-connector-exe
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring >=0.10.10.0 && <1
+    , bytestring
     , hk-kafka-topics-connector
-    , hw-kafka-client >=3.1.0 && <4
+    , hw-kafka-client
   default-language: Haskell2010
 
 executable integration-test
@@ -61,8 +61,8 @@ executable integration-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring >=0.10.10.0 && <1
-    , hw-kafka-client >=3.1.0 && <4
+    , bytestring
+    , hw-kafka-client
   default-language: Haskell2010
 
 test-suite test
@@ -75,7 +75,7 @@ test-suite test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring >=0.10.10.0 && <1
+    , bytestring
     , hk-kafka-topics-connector
-    , hw-kafka-client >=3.1.0 && <4
+    , hw-kafka-client
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -21,8 +21,8 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
 - base >= 4.7 && < 5
-- hw-kafka-client >= 3.1.0 && < 4
-- bytestring >= 0.10.10.0 && < 1
+- bytestring
+- hw-kafka-client
 
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,6 @@ packages:
 #
 extra-deps:
 - hw-kafka-client-3.1.0
-- bytestring-0.10.10.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,13 +11,6 @@ packages:
       sha256: 59c7045a9fbc1ab32f01f0457f6e60c851ea8bce9e0229631e95166d512ca2ae
   original:
     hackage: hw-kafka-client-3.1.0
-- completed:
-    hackage: bytestring-0.10.10.0@sha256:06b2e84f1bc9ab71a162c0ca9e88358dd6bbe5cb7fdda2d6d34b6863c367ec95,8944
-    pantry-tree:
-      size: 2788
-      sha256: 0c8345618e3d7440989d5001ff57d01896548195338bf7a70d8453710a43418b
-  original:
-    hackage: bytestring-0.10.10.0
 snapshots:
 - completed:
     size: 492015


### PR DESCRIPTION
https://docs.haskellstack.org/en/stable/GUIDE/#adding-dependencies
In short:
* packages in the LTS package set should not appear in extra-deps
* we don't need to pin versions in package.yaml as packages in LTS
  are pinned there and packages not in LTS are pinned in extra-deps